### PR TITLE
End override 97127 97123 & optional PCI departement level extract

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -43,11 +43,12 @@ program
 program
   .command('extract-pci <workDir>')
   .description('extract features from EDIGÉO to GeoJSON')
-  .action(workDir => {
+  .option('--departements <departements>', 'codes départements séparés par des virgules, pour limiter le traitement à un sous-ensemble')
+  .action((workDir, {departements}) => {
     if (!workDir) throw new Error('workDir is required')
     workDir = resolve(workDir)
 
-    extractPciCmd(workDir)
+    extractPciCmd(workDir, departements)
   })
 
 program

--- a/lib/commands/extract-pci.js
+++ b/lib/commands/extract-pci.js
@@ -12,15 +12,17 @@ const extractWorkers = new Piscina({
 
 const concurrency = Math.floor(os.cpus().length / 8) || 1
 
-async function doStuff(basePath) {
+async function doStuff(basePath, departements) {
   const edigeoTree = new Tree(basePath, 'dgfip-pci-vecteur', 'edigeo')
   const departementsFound = await edigeoTree.listDepartements()
 
-  return bluebird.map(departementsFound, codeDep => extractDepartement(extractWorkers, basePath, codeDep), {concurrency})
+  const departementsFiltered = departements === undefined ? departementsFound : departementsFound.filter(value => departements.split(',').map(codeDep => codeDep.trim()).includes(value))
+
+  return bluebird.map(departementsFiltered, codeDep => extractDepartement(extractWorkers, basePath, codeDep), {concurrency})
 }
 
-function handler(basePath) {
-  doStuff(basePath)
+function handler(basePath, departements) {
+  doStuff(basePath, departements)
     .then(() => {
       console.log('Terminé avec succès !')
     })

--- a/lib/extract/feuille.js
+++ b/lib/extract/feuille.js
@@ -1,14 +1,9 @@
 import {parse} from '@etalab/edigeo-parser'
-import {getCodeCommune} from '../util/codes.js'
 
 async function extractFeuille(edigeoTree, feuille) {
-  const codeCommune = getCodeCommune(feuille)
   const filePath = edigeoTree.getFeuillePath(feuille)
 
-  // Fix source srsCode for Saint-Martin and Saint-Barthelemy (https://github.com/etalab/cadastre/issues/17)
-  const parseOptions = ['97127', '97123'].includes(codeCommune)
-    ? {overrideSrsCode: 'GUADFM49U20', bundle: feuille}
-    : {bundle: feuille}
+  const parseOptions = {bundle: feuille}
 
   const {layers} = await parse(filePath, parseOptions)
 


### PR DESCRIPTION
- Remove code for fixing source srsCode for Saint-Martin and Saint-Barthelemy https://github.com/etalab/cadastre/issues/17
- Enable in edigeo pci, optional extract at one or more departement instead of only full extract to ease fix and speed up fixes for particular cases